### PR TITLE
Fix a JS issue to make the image chooser working on CMS -> Widget -> Edit area

### DIFF
--- a/app/design/adminhtml/default/default/layout/aijko/widgetimagechooser.xml
+++ b/app/design/adminhtml/default/default/layout/aijko/widgetimagechooser.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0"?>
 <layout>
+	<adminhtml_widget_instance_edit>
+		<reference name="head">			
+			<action method="addJs"><script>lib/flex.js</script></action>
+			<action method="addJs"><script>lib/FABridge.js</script></action>
+			<action method="addJs"><script>mage/adminhtml/flexuploader.js</script></action>
+			<action method="addJs"><script>mage/adminhtml/browser.js</script></action>
+		</reference>
+	</adminhtml_widget_instance_edit>
     <adminhtml_cms_wysiwyg_images_chooser_index>
         <remove name="footer" />
         <remove name="head" />


### PR DESCRIPTION
JS files for the media browser are not included by default in the Edit section of widget instance area.

I fixed that and now the ImageChooser works well into this section also! 
