### PR TITLE
Fix image uploader for 1.9.3 and patch SUPEE-8788

### DIFF
--- a/app/design/adminhtml/default/default/layout/aijko/widgetimagechooser.xml
+++ b/app/design/adminhtml/default/default/layout/aijko/widgetimagechooser.xml
@@ -17,7 +17,9 @@
         </reference>
         <reference name="content">
             <block name="wysiwyg_images.content"  type="adminhtml/cms_wysiwyg_images_content" template="cms/browser/content.phtml">
-                <block name="wysiwyg_images.uploader" type="adminhtml/cms_wysiwyg_images_content_uploader" template="cms/browser/content/uploader.phtml" />
+                <block name="wysiwyg_images.uploader" type="adminhtml/cms_wysiwyg_images_content_uploader" template="media/uploader.phtml">
+                    <block name="additional_scripts" type="core/template" template="cms/browser/content/uploader.phtml"/>
+                </block>
                 <block name="wysiwyg_images.newfolder" type="adminhtml/cms_wysiwyg_images_content_newfolder" template="cms/browser/content/newfolder.phtml" />
             </block>
         </reference>


### PR DESCRIPTION
This fixes the image uploader for Magento v1.9.3 and any other versions with SUPEE-8788 security patch applied. However, this also breaks compatibility with any versions that do not have the patch applied, so do with this as you wish!